### PR TITLE
Make JsonApiConverter independent from process request/response implementations

### DIFF
--- a/cse-export-runner-app/src/main/java/com/farao_community/farao/cse/export/runner/app/CseExportListener.java
+++ b/cse-export-runner-app/src/main/java/com/farao_community/farao/cse/export/runner/app/CseExportListener.java
@@ -103,7 +103,7 @@ public class CseExportListener implements MessageListener  {
     }
 
     private Message createMessageResponse(CseExportResponse cseResponse, String correlationId) {
-        return MessageBuilder.withBody(jsonApiConverter.toJsonMessage(cseResponse))
+        return MessageBuilder.withBody(jsonApiConverter.toJsonMessage(cseResponse, CseExportResponse.class))
                 .andProperties(buildMessageResponseProperties(correlationId))
                 .build();
     }

--- a/cse-runner-api/src/main/java/com/farao_community/farao/cse/runner/api/JsonApiConverter.java
+++ b/cse-runner-api/src/main/java/com/farao_community/farao/cse/runner/api/JsonApiConverter.java
@@ -10,10 +10,6 @@ package com.farao_community.farao.cse.runner.api;
 import com.farao_community.farao.cse.runner.api.exception.AbstractCseException;
 import com.farao_community.farao.cse.runner.api.exception.CseInternalException;
 import com.farao_community.farao.cse.runner.api.exception.CseInvalidDataException;
-import com.farao_community.farao.cse.runner.api.resource.CseExportRequest;
-import com.farao_community.farao.cse.runner.api.resource.CseExportResponse;
-import com.farao_community.farao.cse.runner.api.resource.CseRequest;
-import com.farao_community.farao.cse.runner.api.resource.CseResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -39,7 +35,7 @@ public class JsonApiConverter {
     }
 
     public <T> T fromJsonMessage(byte[] jsonMessage, Class<T> tClass) {
-        ResourceConverter converter = createConverter();
+        ResourceConverter converter = createConverter(tClass);
         try {
             return converter.readDocument(jsonMessage, tClass).get();
         } catch (Exception e) {
@@ -48,8 +44,8 @@ public class JsonApiConverter {
 
     }
 
-    public <T> byte[] toJsonMessage(T jsonApiObject) {
-        ResourceConverter converter = createConverter();
+    public <T> byte[] toJsonMessage(T jsonApiObject, Class<T> clazz) {
+        ResourceConverter converter = createConverter(clazz);
         JSONAPIDocument<?> jsonApiDocument = new JSONAPIDocument<>(jsonApiObject);
         try {
             return converter.writeDocument(jsonApiDocument);
@@ -68,8 +64,8 @@ public class JsonApiConverter {
         }
     }
 
-    private ResourceConverter createConverter() {
-        ResourceConverter converter = new ResourceConverter(objectMapper, CseRequest.class, CseResponse.class, CseExportRequest.class, CseExportResponse.class);
+    private ResourceConverter createConverter(Class<?>... classes) {
+        ResourceConverter converter = new ResourceConverter(objectMapper, classes);
         converter.disableSerializationOption(SerializationFeature.INCLUDE_META);
         return converter;
     }

--- a/cse-runner-app/src/main/java/com/farao_community/farao/cse/runner/app/CseListener.java
+++ b/cse-runner-app/src/main/java/com/farao_community/farao/cse/runner/app/CseListener.java
@@ -103,7 +103,7 @@ public class CseListener implements MessageListener {
     }
 
     private Message createMessageResponse(CseResponse cseResponse, String correlationId) {
-        return MessageBuilder.withBody(jsonApiConverter.toJsonMessage(cseResponse))
+        return MessageBuilder.withBody(jsonApiConverter.toJsonMessage(cseResponse, CseResponse.class))
             .andProperties(buildMessageResponseProperties(correlationId))
             .build();
     }

--- a/cse-runner-spring-boot-starter/src/main/java/com/farao_community/farao/cse/runner/starter/CseClient.java
+++ b/cse-runner-spring-boot-starter/src/main/java/com/farao_community/farao/cse/runner/starter/CseClient.java
@@ -28,19 +28,19 @@ public class CseClient {
         this.cseMessageHandler = new CseMessageHandler(cseClientProperties);
     }
 
-    public <I, J> J run(I request, Class<J> clazz, int priority) {
+    public <I, J> J run(I request, Class<I> requestClass, Class<J> responseClass, int priority) {
         LOGGER.info("Request sent: {}", request);
         Message responseMessage = amqpTemplate.sendAndReceive(
                 cseClientProperties.getBinding().getDestination(),
                 cseClientProperties.getBinding().getRoutingKey(),
-                cseMessageHandler.buildMessage(request, priority)
+                cseMessageHandler.buildMessage(request, requestClass, priority)
         );
-        J response = cseMessageHandler.readMessage(responseMessage, clazz);
+        J response = cseMessageHandler.readMessage(responseMessage, responseClass);
         LOGGER.info("Response received: {}", response);
         return response;
     }
 
-    public <I, J> J run(I request, Class<J> clazz) {
-        return run(request, clazz, DEFAULT_PRIORITY);
+    public <I, J> J run(I request, Class<I> requestClass, Class<J> responseClass) {
+        return run(request, requestClass, responseClass, DEFAULT_PRIORITY);
     }
 }

--- a/cse-runner-spring-boot-starter/src/main/java/com/farao_community/farao/cse/runner/starter/CseMessageHandler.java
+++ b/cse-runner-spring-boot-starter/src/main/java/com/farao_community/farao/cse/runner/starter/CseMessageHandler.java
@@ -25,8 +25,8 @@ public class CseMessageHandler {
         this.jsonConverter = new JsonApiConverter();
     }
 
-    public <I> Message buildMessage(I request, int priority) {
-        return MessageBuilder.withBody(jsonConverter.toJsonMessage(request))
+    public <I> Message buildMessage(I request, Class<I> requestClass, int priority) {
+        return MessageBuilder.withBody(jsonConverter.toJsonMessage(request, requestClass))
                 .andProperties(buildMessageProperties(priority))
                 .build();
     }

--- a/cse-runner-spring-boot-starter/src/test/java/com/farao_community/farao/cse/runner/starter/CseClientTest.java
+++ b/cse-runner-spring-boot-starter/src/test/java/com/farao_community/farao/cse/runner/starter/CseClientTest.java
@@ -35,7 +35,7 @@ class CseClientTest {
 
         Mockito.when(responseMessage.getBody()).thenReturn(getClass().getResourceAsStream("/cseResponseMessage.json").readAllBytes());
         Mockito.when(amqpTemplate.sendAndReceive(Mockito.same("my-exchange"), Mockito.same("#"), Mockito.any())).thenReturn(responseMessage);
-        CseResponse cseResponse = cseClient.run(cseRequest, CseResponse.class);
+        CseResponse cseResponse = cseClient.run(cseRequest, CseRequest.class, CseResponse.class);
 
         assertEquals("ttcFileUrl", cseResponse.getTtcFileUrl());
     }
@@ -49,7 +49,7 @@ class CseClientTest {
 
         Mockito.when(responseMessage.getBody()).thenReturn(getClass().getResourceAsStream("/cseExportResponseMessage.json").readAllBytes());
         Mockito.when(amqpTemplate.sendAndReceive(Mockito.same("my-exchange"), Mockito.same("#"), Mockito.any())).thenReturn(responseMessage);
-        CseExportResponse cseExportResponse = cseClient.run(cseExportRequest, CseExportResponse.class);
+        CseExportResponse cseExportResponse = cseClient.run(cseExportRequest, CseExportRequest.class, CseExportResponse.class);
 
         assertEquals("logsFileUrl", cseExportResponse.getLogsFileUrl());
     }


### PR DESCRIPTION

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
In the aim of splitting repositories for CSE processes we want to make JsonApiConverter independent from process requests and repsonses.

