### PR TITLE
Fix where to save data for CSE runners import and export

### DIFF
--- a/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/CseExportRunner.java
+++ b/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/CseExportRunner.java
@@ -22,7 +22,7 @@ import java.io.IOException;
  */
 @Service
 public class CseExportRunner {
-    private static final String NETWORK_PRE_PROCESSED_FILE_NAME = "network_pre_processed.xiidm";
+    private static final String NETWORK_PRE_PROCESSED_FILE_NAME = "network_pre_processed";
     private final FileImporter fileImporter;
     private final FileExporter fileExporter;
     private final PiSaService pisaService;

--- a/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/FileExporter.java
+++ b/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/FileExporter.java
@@ -48,8 +48,8 @@ public class FileExporter {
     private static final String DIRECTION = "EXPORT";
     private static final String UCTE_EXTENSION = "uct";
     private static final String UCTE_FORMAT = "UCTE";
-    private static final String IIDM_FORMAT = "XIIDM";
-    private static final String IIDM_EXTENSION = "xiidm";
+    private static final String XIIDM_FORMAT = "XIIDM";
+    private static final String XIIDM_EXTENSION = "xiidm";
 
     private final MinioAdapter minioAdapter;
     private final ProcessConfiguration processConfiguration;
@@ -98,8 +98,8 @@ public class FileExporter {
         switch (format) {
             case UCTE_FORMAT:
                 return networkFileName + "." + UCTE_EXTENSION;
-            case IIDM_FORMAT:
-                return networkFileName + "." + IIDM_EXTENSION;
+            case XIIDM_FORMAT:
+                return networkFileName + "." + XIIDM_EXTENSION;
             default:
                 throw new NotImplementedException("Network format %s is not recognized");
         }
@@ -150,9 +150,9 @@ public class FileExporter {
             case UCTE_FORMAT:
                 Exporters.export(UCTE_FORMAT, network, new Properties(), memDataSource);
                 return memDataSource.newInputStream("", UCTE_EXTENSION);
-            case IIDM_FORMAT:
-                Exporters.export(IIDM_FORMAT, network, new Properties(), memDataSource);
-                return memDataSource.newInputStream("", IIDM_EXTENSION);
+            case XIIDM_FORMAT:
+                Exporters.export(XIIDM_FORMAT, network, new Properties(), memDataSource);
+                return memDataSource.newInputStream("", XIIDM_EXTENSION);
             default:
                 throw new UnsupportedOperationException(String.format("Network format %s not supported.", format));
         }

--- a/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/FileExporter.java
+++ b/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/FileExporter.java
@@ -76,20 +76,17 @@ public class FileExporter {
     }
 
     String saveNetwork(Network network, String format, GridcapaFileGroup fileGroup, ProcessType processType, String networkFilename, OffsetDateTime processTargetDate) {
-        String networkPath;
+        String networkPath = getDestinationPath(processTargetDate, processType, fileGroup) + addExtension(networkFilename, format);
         try (InputStream is = getNetworkInputStream(network, format)) {
             switch (fileGroup) {
                 case ARTIFACT:
-                    networkPath = getDestinationPath(processTargetDate, processType, GridcapaFileGroup.ARTIFACT) + addExtension(networkFilename, format);
                     minioAdapter.uploadArtifactForTimestamp(networkPath, is, adaptTargetProcessName(processType), "", processTargetDate);
                     break;
                 case OUTPUT:
-                    networkPath = getDestinationPath(processTargetDate, processType, GridcapaFileGroup.OUTPUT) + addExtension(networkFilename, format);
                     minioAdapter.uploadOutputForTimestamp(networkPath, is, adaptTargetProcessName(processType), processConfiguration.getFinalCgm(), processTargetDate);
                     break;
                 default:
                     throw new UnsupportedOperationException(String.format("File group %s not supported", fileGroup));
-
             }
         } catch (IOException e) {
             throw new CseInternalException("Error while trying to save network", e);

--- a/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/FileExporter.java
+++ b/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/FileExporter.java
@@ -99,9 +99,9 @@ public class FileExporter {
 
     private static String addExtension(String networkFileName, String format) {
         switch (format) {
-            case "UCTE":
+            case UCTE_FORMAT:
                 return networkFileName + "." + UCTE_EXTENSION;
-            case "XIIDM":
+            case IIDM_FORMAT:
                 return networkFileName + "." + IIDM_EXTENSION;
             default:
                 throw new NotImplementedException("Network format %s is not recognized");

--- a/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/FileExporter.java
+++ b/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/FileExporter.java
@@ -76,7 +76,7 @@ public class FileExporter {
     }
 
     String saveNetwork(Network network, String format, GridcapaFileGroup fileGroup, ProcessType processType, String networkFilename, OffsetDateTime processTargetDate) {
-        String networkPath = getDestinationPath(processTargetDate, processType, fileGroup) + addExtension(networkFilename, format);
+        String networkPath = getDestinationPath(processTargetDate, processType, fileGroup) + getNetworkFilenameWithExtension(networkFilename, format);
         try (InputStream is = getNetworkInputStream(network, format)) {
             switch (fileGroup) {
                 case ARTIFACT:
@@ -94,7 +94,7 @@ public class FileExporter {
         return minioAdapter.generatePreSignedUrl(networkPath);
     }
 
-    private static String addExtension(String networkFileName, String format) {
+    private static String getNetworkFilenameWithExtension(String networkFileName, String format) {
         switch (format) {
             case UCTE_FORMAT:
                 return networkFileName + "." + UCTE_EXTENSION;

--- a/cse-cc-export-runner-app/src/test/java/com/farao_community/farao/cse/export_runner/app/services/FileExporterTest.java
+++ b/cse-cc-export-runner-app/src/test/java/com/farao_community/farao/cse/export_runner/app/services/FileExporterTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.farao_community.farao.cse.export_runner.app.services;
+
+import com.farao_community.farao.cse.data.xsd.ttc_rao.CseRaoResult;
+import com.farao_community.farao.cse.export_runner.app.configurations.ProcessConfiguration;
+import com.farao_community.farao.cse.runner.api.resource.ProcessType;
+import com.farao_community.farao.data.crac_api.Crac;
+import com.farao_community.farao.minio_adapter.starter.GridcapaFileGroup;
+import com.farao_community.farao.minio_adapter.starter.MinioAdapter;
+import com.powsybl.iidm.network.Network;
+import org.apache.commons.io.FilenameUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+
+/**
+ * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
+ */
+@SpringBootTest
+class FileExporterTest {
+
+    @MockBean
+    MinioAdapter minioAdapter;
+
+    private MinioMock minioMock;
+
+    @SpyBean
+    FileExporter fileExporter;
+
+    @Autowired
+    ProcessConfiguration processConfiguration;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        minioMock = new MinioMock();
+        Mockito.doAnswer(invocation -> {
+            String path = (String) invocation.getArguments()[0];
+            String processTag = (String) invocation.getArguments()[2];
+            String fileType = (String) invocation.getArguments()[3];
+            minioMock.addEntry(path, new MinioMock.MinioEntry(FilenameUtils.getName(path), GridcapaFileGroup.ARTIFACT, processTag, fileType));
+            return null;
+        }).when(minioAdapter).uploadArtifactForTimestamp(any(), any(), any(), any(), any());
+
+        Mockito.doAnswer(invocation -> {
+            String path = (String) invocation.getArguments()[0];
+            String processTag = (String) invocation.getArguments()[2];
+            String fileType = (String) invocation.getArguments()[3];
+            minioMock.addEntry(path, new MinioMock.MinioEntry(FilenameUtils.getName(path), GridcapaFileGroup.OUTPUT, processTag, fileType));
+            return null;
+        }).when(minioAdapter).uploadOutputForTimestamp(any(), any(), any(), any(), any());
+
+        Mockito.doReturn(new ByteArrayInputStream("test data".getBytes())).when(fileExporter).getNetworkInputStream(any(), anyString());
+    }
+
+    @Test
+    void testSaveFinalCgmForIdccProcess() {
+        fileExporter.saveNetwork(
+            Mockito.mock(Network.class),
+            "XIIDM",
+            GridcapaFileGroup.OUTPUT,
+            ProcessType.IDCC,
+            "network-test",
+            OffsetDateTime.parse("2021-01-01T15:30Z")
+        );
+
+        MinioMock.MinioEntry minioEntry = minioMock.getEntry("CSE/EXPORT/IDCC/2021/01/01/16_30/OUTPUT/network-test.xiidm");
+        assertNotNull(minioEntry);
+        assertEquals("network-test.xiidm", minioEntry.getFilename());
+        assertEquals(processConfiguration.getFinalCgm(), minioEntry.getFileType());
+        assertEquals("CSE_EXPORT_IDCC", minioEntry.getProcessTag());
+        assertEquals(GridcapaFileGroup.OUTPUT, minioEntry.getGridcapaFileGroup());
+    }
+
+    @Test
+    void testSaveFinalCgmForIdccProcessInUcteFormat() {
+        fileExporter.saveNetwork(
+            Mockito.mock(Network.class),
+            "UCTE",
+            GridcapaFileGroup.OUTPUT,
+            ProcessType.IDCC,
+            "network-test",
+            OffsetDateTime.parse("2021-01-01T15:30Z")
+        );
+
+        MinioMock.MinioEntry minioEntry = minioMock.getEntry("CSE/EXPORT/IDCC/2021/01/01/16_30/OUTPUT/network-test.uct");
+        assertNotNull(minioEntry);
+        assertEquals("network-test.uct", minioEntry.getFilename());
+        assertEquals(processConfiguration.getFinalCgm(), minioEntry.getFileType());
+        assertEquals("CSE_EXPORT_IDCC", minioEntry.getProcessTag());
+        assertEquals(GridcapaFileGroup.OUTPUT, minioEntry.getGridcapaFileGroup());
+    }
+
+    @Test
+    void testSavePreProcessedCgmForIdccProcess() {
+        fileExporter.saveNetwork(
+            Mockito.mock(Network.class),
+            "XIIDM",
+            GridcapaFileGroup.ARTIFACT,
+            ProcessType.IDCC,
+            "network-test",
+            OffsetDateTime.parse("2021-01-01T15:30Z")
+        );
+
+        MinioMock.MinioEntry minioEntry = minioMock.getEntry("CSE/EXPORT/IDCC/2021/01/01/16_30/ARTIFACT/network-test.xiidm");
+        assertNotNull(minioEntry);
+        assertEquals("network-test.xiidm", minioEntry.getFilename());
+        assertEquals("", minioEntry.getFileType());
+        assertEquals("CSE_EXPORT_IDCC", minioEntry.getProcessTag());
+        assertEquals(GridcapaFileGroup.ARTIFACT, minioEntry.getGridcapaFileGroup());
+    }
+
+    @Test
+    void testSaveCracInJsonFormatForD2ccProcess() {
+        fileExporter.saveCracInJsonFormat(
+            Mockito.mock(Crac.class),
+            ProcessType.D2CC,
+            OffsetDateTime.parse("2021-01-01T15:30Z")
+        );
+
+        MinioMock.MinioEntry minioEntry = minioMock.getEntry("CSE/EXPORT/D2CC/2021/01/01/16_30/ARTIFACT/crac.json");
+        assertNotNull(minioEntry);
+        assertEquals("crac.json", minioEntry.getFilename());
+        assertEquals("", minioEntry.getFileType());
+        assertEquals("CSE_EXPORT_D2CC", minioEntry.getProcessTag());
+        assertEquals(GridcapaFileGroup.ARTIFACT, minioEntry.getGridcapaFileGroup());
+    }
+
+    @Test
+    void testSaveCracInJsonFormatForIdccProcess() {
+        fileExporter.saveCracInJsonFormat(
+            Mockito.mock(Crac.class),
+            ProcessType.IDCC,
+            OffsetDateTime.parse("2021-01-01T15:30Z")
+        );
+
+        MinioMock.MinioEntry minioEntry = minioMock.getEntry("CSE/EXPORT/IDCC/2021/01/01/16_30/ARTIFACT/crac.json");
+        assertNotNull(minioEntry);
+        assertEquals("crac.json", minioEntry.getFilename());
+        assertEquals("", minioEntry.getFileType());
+        assertEquals("CSE_EXPORT_IDCC", minioEntry.getProcessTag());
+        assertEquals(GridcapaFileGroup.ARTIFACT, minioEntry.getGridcapaFileGroup());
+    }
+
+    @Test
+    void testSaveRaoParametersForD2ccProcess() {
+        fileExporter.saveRaoParameters(
+            ProcessType.D2CC,
+            OffsetDateTime.parse("2021-01-01T15:30Z")
+        );
+
+        MinioMock.MinioEntry minioEntry = minioMock.getEntry("CSE/EXPORT/D2CC/2021/01/01/16_30/ARTIFACT/raoParameters.json");
+        assertNotNull(minioEntry);
+        assertEquals("raoParameters.json", minioEntry.getFilename());
+        assertEquals("", minioEntry.getFileType());
+        assertEquals("CSE_EXPORT_D2CC", minioEntry.getProcessTag());
+        assertEquals(GridcapaFileGroup.ARTIFACT, minioEntry.getGridcapaFileGroup());
+    }
+
+    @Test
+    void testSaveRaoParametersForIdccProcess() {
+        fileExporter.saveRaoParameters(
+            ProcessType.IDCC,
+            OffsetDateTime.parse("2021-01-01T15:30Z")
+        );
+
+        MinioMock.MinioEntry minioEntry = minioMock.getEntry("CSE/EXPORT/IDCC/2021/01/01/16_30/ARTIFACT/raoParameters.json");
+        assertNotNull(minioEntry);
+        assertEquals("raoParameters.json", minioEntry.getFilename());
+        assertEquals("", minioEntry.getFileType());
+        assertEquals("CSE_EXPORT_IDCC", minioEntry.getProcessTag());
+        assertEquals(GridcapaFileGroup.ARTIFACT, minioEntry.getGridcapaFileGroup());
+    }
+
+    @Test
+    void testSaveTtcRaoForD2ccProcess() {
+        fileExporter.saveTtcRao(
+            Mockito.mock(CseRaoResult.class),
+            ProcessType.D2CC,
+            OffsetDateTime.parse("2021-01-01T15:30Z")
+        );
+
+        MinioMock.MinioEntry minioEntry = minioMock.getEntry("CSE/EXPORT/D2CC/2021/01/01/16_30/OUTPUT/TTC_Calculation_20210101_1630_2D0_CO_RAO_Transit_CSE0.xml");
+        assertNotNull(minioEntry);
+        assertEquals("TTC_Calculation_20210101_1630_2D0_CO_RAO_Transit_CSE0.xml", minioEntry.getFilename());
+        assertEquals(processConfiguration.getTtcRao(), minioEntry.getFileType());
+        assertEquals("CSE_EXPORT_D2CC", minioEntry.getProcessTag());
+        assertEquals(GridcapaFileGroup.OUTPUT, minioEntry.getGridcapaFileGroup());
+    }
+
+    @Test
+    void testSaveTtcRaoForIdccProcess() {
+        fileExporter.saveTtcRao(
+            Mockito.mock(CseRaoResult.class),
+            ProcessType.IDCC,
+            OffsetDateTime.parse("2021-01-01T15:30Z")
+        );
+
+        MinioMock.MinioEntry minioEntry = minioMock.getEntry("CSE/EXPORT/IDCC/2021/01/01/16_30/OUTPUT/TTC_Calculation_20210101_1630_2D0_CO_RAO_Transit_CSE0.xml");
+        assertNotNull(minioEntry);
+        assertEquals("TTC_Calculation_20210101_1630_2D0_CO_RAO_Transit_CSE0.xml", minioEntry.getFilename());
+        assertEquals(processConfiguration.getTtcRao(), minioEntry.getFileType());
+        assertEquals("CSE_EXPORT_IDCC", minioEntry.getProcessTag());
+        assertEquals(GridcapaFileGroup.OUTPUT, minioEntry.getGridcapaFileGroup());
+    }
+}

--- a/cse-cc-export-runner-app/src/test/java/com/farao_community/farao/cse/export_runner/app/services/MinioMock.java
+++ b/cse-cc-export-runner-app/src/test/java/com/farao_community/farao/cse/export_runner/app/services/MinioMock.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.farao_community.farao.cse.export_runner.app.services;
+
+import com.farao_community.farao.minio_adapter.starter.GridcapaFileGroup;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
+ */
+public class MinioMock {
+
+    private final Map<String, MinioEntry> minioEntriesByPath = new HashMap<>();
+
+    public MinioEntry getEntry(String path) {
+        return minioEntriesByPath.get(path);
+    }
+
+    public void addEntry(String path, MinioEntry minioEntry) {
+        minioEntriesByPath.put(path, minioEntry);
+    }
+
+    public static final class MinioEntry {
+        private final String filename;
+        private final GridcapaFileGroup gridcapaFileGroup;
+        private final String processTag;
+        private final String fileType;
+
+        public MinioEntry(String filename, GridcapaFileGroup gridcapaFileGroup, String processTag, String fileType) {
+            this.filename = filename;
+            this.gridcapaFileGroup = gridcapaFileGroup;
+            this.processTag = processTag;
+            this.fileType = fileType;
+        }
+
+        public String getFilename() {
+            return filename;
+        }
+
+        public GridcapaFileGroup getGridcapaFileGroup() {
+            return gridcapaFileGroup;
+        }
+
+        public String getProcessTag() {
+            return processTag;
+        }
+
+        public String getFileType() {
+            return fileType;
+        }
+    }
+}

--- a/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/util/MinioStorageHelper.java
+++ b/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/util/MinioStorageHelper.java
@@ -20,6 +20,7 @@ public final class MinioStorageHelper {
 
     private static final String MINIO_SEPARATOR = "/";
     private static final String REGION = "CSE";
+    private static final String DIRECTION = "IMPORT";
 
     private MinioStorageHelper() {
         // should not be constructed
@@ -28,6 +29,7 @@ public final class MinioStorageHelper {
     public static String makeDestinationMinioPath(OffsetDateTime offsetDateTime, ProcessType processType, FileKind filekind, ZoneId zoneId) {
         ZonedDateTime targetDateTime = offsetDateTime.atZoneSameInstant(zoneId);
         return REGION + MINIO_SEPARATOR
+            + DIRECTION + MINIO_SEPARATOR
             + processType + MINIO_SEPARATOR
             + targetDateTime.getYear() + MINIO_SEPARATOR
             + String.format("%02d", targetDateTime.getMonthValue()) + MINIO_SEPARATOR

--- a/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/FileExporterTest.java
+++ b/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/FileExporterTest.java
@@ -45,7 +45,7 @@ class FileExporterTest {
     @Test
     void getTTcFilePathForD2ccProcessTest() {
         String actualFilePath = fileExporter.getFilePath(OffsetDateTime.parse("2021-09-13T12:30Z"), ProcessType.D2CC);
-        String expectedFilePath = "CSE/D2CC/2021/09/13/14_30/OUTPUTS/TTC_Calculation_20210913_1430_2D0_CO_CSE1.xml";
+        String expectedFilePath = "CSE/IMPORT/D2CC/2021/09/13/14_30/OUTPUTS/TTC_Calculation_20210913_1430_2D0_CO_CSE1.xml";
         assertEquals(expectedFilePath, actualFilePath);
         FilenameUtils.getPathNoEndSeparator("CSE/D2CC/2021/");
     }
@@ -53,35 +53,35 @@ class FileExporterTest {
     @Test
     void getTTcFilePathForIdccProcessTest() {
         String actualFilePath = fileExporter.getFilePath(OffsetDateTime.parse("2021-09-13T23:30Z"), ProcessType.IDCC);
-        String expectedFilePath = "CSE/IDCC/2021/09/14/01_30/OUTPUTS/20210914_XBID2_TTCRes_CSE1.xml";
+        String expectedFilePath = "CSE/IMPORT/IDCC/2021/09/14/01_30/OUTPUTS/20210914_XBID2_TTCRes_CSE1.xml";
         assertEquals(expectedFilePath, actualFilePath);
     }
 
     @Test
     void getFinalNetworkFilePathForD2ccProcesTest() {
         String actualFilePath = fileExporter.getFinalNetworkFilePath(OffsetDateTime.parse("2021-09-13T12:30Z"), ProcessType.D2CC);
-        String expectedFilePath = "CSE/D2CC/2021/09/13/14_30/OUTPUTS/20210913_1430_2D1_CO_Final_CSE1.uct";
+        String expectedFilePath = "CSE/IMPORT/D2CC/2021/09/13/14_30/OUTPUTS/20210913_1430_2D1_CO_Final_CSE1.uct";
         assertEquals(expectedFilePath, actualFilePath);
     }
 
     @Test
     void getFinalNetworkFilePathForIdccProcesTest() {
         String actualFilePath = fileExporter.getFinalNetworkFilePath(OffsetDateTime.parse("2021-09-01T17:30Z"), ProcessType.IDCC);
-        String expectedFilePath = "CSE/IDCC/2021/09/01/19_30/OUTPUTS/20210901_1930_173_CSE1.uct";
+        String expectedFilePath = "CSE/IMPORT/IDCC/2021/09/01/19_30/OUTPUTS/20210901_1930_173_CSE1.uct";
         assertEquals(expectedFilePath, actualFilePath);
     }
 
     @Test
     void getBaseCaseFilePathForIdccProcesTest() {
         String actualFilePath = fileExporter.getBaseCaseFilePath(OffsetDateTime.parse("2021-01-01T15:30Z"), ProcessType.IDCC);
-        String expectedFilePath = "CSE/IDCC/2021/01/01/16_30/OUTPUTS/20210101_1630_155_Initial_CSE1.uct";
+        String expectedFilePath = "CSE/IMPORT/IDCC/2021/01/01/16_30/OUTPUTS/20210101_1630_155_Initial_CSE1.uct";
         assertEquals(expectedFilePath, actualFilePath);
     }
 
     @Test
     void getBaseCaseFilePathForD2ccProcesTest() {
         String actualFilePath = fileExporter.getBaseCaseFilePath(OffsetDateTime.parse("2021-01-01T12:30Z"), ProcessType.D2CC);
-        String expectedFilePath = "CSE/D2CC/2021/01/01/13_30/OUTPUTS/20210101_1330_2D5_CO_CSE1.uct";
+        String expectedFilePath = "CSE/IMPORT/D2CC/2021/01/01/13_30/OUTPUTS/20210101_1330_2D5_CO_CSE1.uct";
         assertEquals(expectedFilePath, actualFilePath);
     }
 

--- a/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/util/MinioStorageHelperTest.java
+++ b/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/util/MinioStorageHelperTest.java
@@ -21,16 +21,16 @@ class MinioStorageHelperTest {
 
     @Test
     void makeArtifactsMinioDestinationPathTest() {
-        assertEquals("CSE/D2CC/2022/01/28/11_30/ARTIFACTS/", MinioStorageHelper.makeDestinationMinioPath(OffsetDateTime.parse("2022-01-28T10:30Z"), ProcessType.D2CC, MinioStorageHelper.FileKind.ARTIFACTS, ZoneId.of("Europe/Paris")));
+        assertEquals("CSE/IMPORT/D2CC/2022/01/28/11_30/ARTIFACTS/", MinioStorageHelper.makeDestinationMinioPath(OffsetDateTime.parse("2022-01-28T10:30Z"), ProcessType.D2CC, MinioStorageHelper.FileKind.ARTIFACTS, ZoneId.of("Europe/Paris")));
     }
 
     @Test
     void makeOutputsMinioDestinationPathTest() {
-        assertEquals("CSE/IDCC/2022/01/28/16_30/OUTPUTS/", MinioStorageHelper.makeDestinationMinioPath(OffsetDateTime.parse("2022-01-28T15:30Z"), ProcessType.IDCC, MinioStorageHelper.FileKind.OUTPUTS, ZoneId.of("Europe/Paris")));
+        assertEquals("CSE/IMPORT/IDCC/2022/01/28/16_30/OUTPUTS/", MinioStorageHelper.makeDestinationMinioPath(OffsetDateTime.parse("2022-01-28T15:30Z"), ProcessType.IDCC, MinioStorageHelper.FileKind.OUTPUTS, ZoneId.of("Europe/Paris")));
     }
 
     @Test
     void makeAConfigurationsMinioDestinationPathTest() {
-        assertEquals("CSE/D2CC/2022/01/28/20_30/ARTIFACTS/", MinioStorageHelper.makeDestinationMinioPath(OffsetDateTime.parse("2022-01-28T19:30Z"), ProcessType.D2CC, MinioStorageHelper.FileKind.ARTIFACTS, ZoneId.of("Europe/Paris")));
+        assertEquals("CSE/IMPORT/D2CC/2022/01/28/20_30/ARTIFACTS/", MinioStorageHelper.makeDestinationMinioPath(OffsetDateTime.parse("2022-01-28T19:30Z"), ProcessType.D2CC, MinioStorageHelper.FileKind.ARTIFACTS, ZoneId.of("Europe/Paris")));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Modify FileExporter for both CSE runners (import and export). Make them save files in respectively IMPORT and EXPORT subfolders.
Fix a behavior on export corner, artifacts and outputs were not saved according to task timestamp.
