### PR TITLE
Remove binder group as default for stop task queue

### DIFF
--- a/cse-cc-import-runner-app/src/main/resources/application.yml
+++ b/cse-cc-import-runner-app/src/main/resources/application.yml
@@ -14,7 +14,6 @@ spring:
         definition: interrupt;request
       default:
         binder: rabbit
-        group: cse-idcc-runner
       bindings:
         interrupt-in-0:
           destination: cse-interrupt


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
