### PR TITLE
 invert regulation value when exporting cgm

### DIFF
--- a/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/services/MerchantLineService.java
+++ b/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/services/MerchantLineService.java
@@ -80,4 +80,8 @@ public class MerchantLineService {
         }
         return mendrisioCagnoTargetFlow;
     }
+
+    void postProcessingMerchantLine(Network network) {
+        uctePstProcessor.invertRegulationValueForIdcc(network);
+    }
 }

--- a/cse-lib/network-processing/src/main/java/com/farao_community/farao/cse/network_processing/ucte_pst_change/UctePstProcessor.java
+++ b/cse-lib/network-processing/src/main/java/com/farao_community/farao/cse/network_processing/ucte_pst_change/UctePstProcessor.java
@@ -82,4 +82,14 @@ public final class UctePstProcessor {
             return transformer.getTerminal1();
         }
     }
+
+    /**
+     * Regulation value initially inverted in preprocessing for IDCC process to prevent an issue that comes from PowSyBl UCTE importer
+     * should be re-inverted when exporting UCTE network
+     */
+    public void invertRegulationValueForIdcc(Network network) {
+        TwoWindingsTransformer transformer = network.getTwoWindingsTransformer(pstId);
+        PhaseTapChanger phaseTapChanger = getPhaseTapChanger(transformer);
+        phaseTapChanger.setRegulationValue(-phaseTapChanger.getRegulationValue());
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the new behavior (if this is a feature change)?**
Regulation value initially inverted in preprocessing for IDCC process to prevent an issue that comes from PowSyBl UCTE importer  re-inverted when exporting UCTE network


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
No


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
