### PR TITLE
Replace "iterative" scaling parameter since it is deprecated

### DIFF
--- a/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/services/InitialShiftService.java
+++ b/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/services/InitialShiftService.java
@@ -95,9 +95,9 @@ public class InitialShiftService {
 
         network.getVariantManager().cloneVariant(initialVariantId, newVariant, true);
         network.getVariantManager().setWorkingVariant(newVariant);
-        ScalingParameters scalingParameters = new ScalingParameters();
-        scalingParameters.setIterative(true);
-        scalingParameters.setReconnect(true);
+        ScalingParameters scalingParameters = new ScalingParameters()
+                .setPriority(ScalingParameters.Priority.RESPECT_OF_VOLUME_ASKED)
+                .setReconnect(true);
         for (Map.Entry<String, Double> entry : scalingValuesByCountry.entrySet()) {
             String zoneId = entry.getKey();
             double asked = entry.getValue();

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
         <!-- BUSINESS DEPENDENCIES -->
         <farao.dependencies.version>1.35.0</farao.dependencies.version>
-        <farao.dichotomy.version>4.22.0</farao.dichotomy.version>
+        <farao.dichotomy.version>4.22.1</farao.dichotomy.version>
         <gridcapa.rao.runner.version>1.30.0</gridcapa.rao.runner.version>
         <gridcapa.task-manager.version>1.33.0</gridcapa.task-manager.version>
         <gridcapa.starter.minio.adapter.version>1.3.0</gridcapa.starter.minio.adapter.version>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced scaling operations with prioritized settings for network shifts, particularly for Italy.
	- Added warning logs for discrepancies in shift values.

- **Bug Fixes**
	- Improved error handling and logging during the scaling process.

- **Chores**
	- Updated the version of the `farao.dichotomy` dependency to `4.22.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->