### PR TITLE
Don't update the input network with the initial shift

### DIFF
--- a/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/services/InitialShiftService.java
+++ b/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/services/InitialShiftService.java
@@ -118,10 +118,6 @@ public class InitialShiftService {
                 }
             }
         }
-        //Save shift in the initial variant
-        network.getVariantManager().cloneVariant(newVariant, initialVariantId, true);
-        network.getVariantManager().setWorkingVariant(initialVariantId);
-        network.getVariantManager().removeVariant(newVariant);
 
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined network state management by removing redundant handling after scaling operations.
	- Maintained effective scaling adjustments, ensuring that variations and regional parameters are processed accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->