### PR TITLE
[Import] Check if Cse response is interrupted before all rao failed

### DIFF
--- a/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/services/RequestService.java
+++ b/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/services/RequestService.java
@@ -65,11 +65,11 @@ public class RequestService {
 
     private void updateTaskStatus(final CseResponse cseResponse) {
         final String responseId = cseResponse.getId();
-        if (cseResponse.isRaoFailed()) {
-            sendTaskStatusUpdate(responseId, TaskStatus.ERROR);
-        } else if (cseResponse.isInterrupted()) {
+        if (cseResponse.isInterrupted()) {
             businessLogger.info("CSE run has been interrupted");
             sendTaskStatusUpdate(responseId, TaskStatus.INTERRUPTED);
+        } else if (cseResponse.isRaoFailed()) {
+            sendTaskStatusUpdate(responseId, TaskStatus.ERROR);
         } else {
             sendTaskStatusUpdate(responseId, TaskStatus.SUCCESS);
         }

--- a/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/RequestServiceTest.java
+++ b/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/RequestServiceTest.java
@@ -82,7 +82,7 @@ class RequestServiceTest {
         String id = UUID.randomUUID().toString();
         String runId = UUID.randomUUID().toString();
         CseRequest cseRequest = new CseRequest(id, runId, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, 0, 0.0, 0.0, null, false);
-        CseResponse cseResponse = new CseResponse(cseRequest.getId(), "null", "null", true, false);
+        CseResponse cseResponse = new CseResponse(cseRequest.getId(), "null", "null", true, true);
         byte[] req = jsonApiConverter.toJsonMessage(cseRequest, CseRequest.class);
         when(cseServer.run(any())).thenReturn(cseResponse);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task status updates by prioritizing interruption conditions over error states, ensuring more accurate feedback.
  
- **Tests**
  - Updated test scenarios to align with the revised task status update logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->