### PR TITLE
Do not export the results in case of interruption

### DIFF
--- a/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/CseExportRunner.java
+++ b/cse-cc-export-runner-app/src/main/java/com/farao_community/farao/cse/export_runner/app/services/CseExportRunner.java
@@ -86,7 +86,7 @@ public class CseExportRunner {
         if (checkIsInterrupted(cseExportRequest)) {
             businessLogger.warn("Computation has been interrupted for timestamp {}", cseExportRequest.getTargetProcessDateTime());
             LOGGER.info("Response sent for timestamp {} : run has been interrupted", cseExportRequest.getTargetProcessDateTime());
-            return new CseExportResponse(cseExportRequest.getId(), ttcRaoService.saveFailedTtcRao(cseExportRequest), "", true);
+            return new CseExportResponse(cseExportRequest.getId(), "", "", true);
         }
 
         // Check on cgm file name

--- a/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/CseRunnerTest.java
+++ b/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/CseRunnerTest.java
@@ -147,15 +147,12 @@ class CseRunnerTest {
         when(dichotomyResult.isInterrupted()).thenReturn(true);
         when(dichotomyResult.getBestDichotomyResult()).thenThrow(new IndexOutOfBoundsException());
 
-        when(ttcResultService.saveFailedTtcResult(any(), any(), any())).thenReturn("interruptedTTCFilePath");
-
         // WHEN
         CseResponse response = cseRunner.run(cseRequest);
 
         // THEN
-        verify(ttcResultService, times(1)).saveFailedTtcResult(eq(cseRequest), any(), eq(TtcResult.FailedProcessData.FailedProcessReason.OTHER));
         assertNotNull(response);
-        assertEquals("interruptedTTCFilePath", response.getTtcFileUrl());
+        assertEquals("", response.getTtcFileUrl());
         assertTrue(response.isInterrupted());
     }
 
@@ -167,15 +164,12 @@ class CseRunnerTest {
         when(restTemplateBuilder.build()).thenReturn(restTemplate);
         when(restTemplate.getForEntity(anyString(), eq(Boolean.class))).thenReturn(ResponseEntity.ok(true));
 
-        when(ttcResultService.saveFailedTtcResult(any(), any(), any())).thenReturn("interruptedTTCFilePath");
-
         // WHEN
         CseResponse response = cseRunner.run(cseRequest);
 
         // THEN
-        verify(ttcResultService, times(1)).saveFailedTtcResult(eq(cseRequest), any(), eq(TtcResult.FailedProcessData.FailedProcessReason.OTHER));
         assertNotNull(response);
-        assertEquals("interruptedTTCFilePath", response.getTtcFileUrl());
+        assertEquals("", response.getTtcFileUrl());
         assertTrue(response.isInterrupted());
     }
 
@@ -187,6 +181,7 @@ class CseRunnerTest {
 
         CseRequest cseRequest = buildTestCseRequest();
         MultipleDichotomyResult<DichotomyRaoResponse> dichotomyResult = new MultipleDichotomyResult<>();
+        dichotomyResult.setInterrupted(false);
         dichotomyResult.setRaoFailed(true);
         when(multipleDichotomyRunner.runMultipleDichotomy(
                 any(CseRequest.class),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of interrupted computations by ensuring that, when interrupted, responses now return empty URLs instead of saving failed results.
- **Tests**
	- Updated tests to reflect the new behavior for interrupted computations, verifying that empty URLs are returned and removing checks for saving failed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->