### PR TITLE
Export UCTE network in case of Loadflow divergence during initial shift

### DIFF
--- a/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/dichotomy/CseNetworkExporter.java
+++ b/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/dichotomy/CseNetworkExporter.java
@@ -32,16 +32,20 @@ public class CseNetworkExporter implements NetworkExporter {
 
     @Override
     public void export(final Network network) {
+        final String variantName = network.getVariantManager().getWorkingVariantId();
+        export(network, variantName);
+    }
+
+    public void export(final Network network, String step) {
         final OffsetDateTime processTargetDateTime = cseRequest.getTargetProcessDateTime();
         final ProcessType processType = cseRequest.getProcessType();
         final boolean isImportEcProcess = cseRequest.isImportEcProcess();
 
         final String basePath = MinioStorageHelper.makeDestinationMinioPath(processTargetDateTime, processType, MinioStorageHelper.FileKind.ARTIFACTS, ZoneId.of(fileExporter.getZoneId()), isImportEcProcess);
-        final String variantName = network.getVariantManager().getWorkingVariantId();
         final String separator = basePath.endsWith("/") ? "" : "/";
-        final String baseDirPathForCurrentStep = String.format("%s%s%s/", basePath, separator, variantName);
+        final String baseDirPathForCurrentStep = String.format("%s%s%s/", basePath, separator, step);
 
-        final String scaledNetworkInUcteFormatName = network.getNameOrId() + ".uct";
+        final String scaledNetworkInUcteFormatName = network.getNameOrId() + "-diverged.uct";
         final String filePath = baseDirPathForCurrentStep + scaledNetworkInUcteFormatName;
 
         LOGGER.info("Exporting network at: {}", filePath);

--- a/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/services/InitialShiftService.java
+++ b/cse-cc-import-runner-app/src/main/java/com/farao_community/farao/cse/import_runner/app/services/InitialShiftService.java
@@ -74,7 +74,11 @@ public class InitialShiftService {
         try {
             return BorderExchanges.computeCseCountriesBalances(network);
         } catch (LoadflowComputationException e) {
-            new CseNetworkExporter(cseRequest, fileExporter).export(network, stepSuffix);
+            try {
+                new CseNetworkExporter(cseRequest, fileExporter).export(network, stepSuffix);
+            } catch (Exception ex) {
+                businessLogger.error("Could not export network: {}", ex.getMessage());
+            }
             throw e;
         }
     }

--- a/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/dichotomy/CseNetworkExporterTest.java
+++ b/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/dichotomy/CseNetworkExporterTest.java
@@ -58,6 +58,6 @@ class CseNetworkExporterTest {
                 Mockito.eq(ProcessType.D2CC),
                 Mockito.eq(true));
 
-        Assertions.assertThat(captor.getValue()).isEqualTo("CSE/IMPORT_EC/D2CC/2025/06/20/15_30/ARTIFACTS/variantId/testId.uct");
+        Assertions.assertThat(captor.getValue()).isEqualTo("CSE/IMPORT_EC/D2CC/2025/06/20/15_30/ARTIFACTS/variantId/testId-diverged.uct");
     }
 }

--- a/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/CseRunnerTest.java
+++ b/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/CseRunnerTest.java
@@ -210,6 +210,7 @@ class CseRunnerTest {
         RestTemplate restTemplate = mock(RestTemplate.class);
         when(restTemplateBuilder.build()).thenReturn(restTemplate);
         when(restTemplate.getForEntity(anyString(), eq(Boolean.class))).thenReturn(ResponseEntity.ok(false));
+        when(fileExporter.getZoneId()).thenReturn("UTC+2");
 
         CseRequest cseRequest = buildTestCseRequest();
 

--- a/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/InitialShiftServiceTest.java
+++ b/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/InitialShiftServiceTest.java
@@ -7,14 +7,28 @@
 
 package com.farao_community.farao.cse.import_runner.app.services;
 
+import com.farao_community.farao.cse.computation.BorderExchanges;
+import com.farao_community.farao.cse.computation.LoadflowComputationException;
 import com.farao_community.farao.cse.data.ntc.Ntc;
 import com.farao_community.farao.cse.import_runner.app.CseData;
 import com.farao_community.farao.cse.import_runner.app.dichotomy.CseCountry;
+import com.farao_community.farao.cse.import_runner.app.dichotomy.CseNetworkExporter;
+import com.farao_community.farao.cse.import_runner.app.dichotomy.NetworkShifterUtil;
+import com.farao_community.farao.cse.import_runner.app.dichotomy.ZonalScalableProvider;
+import com.farao_community.farao.cse.runner.api.resource.CseRequest;
+import com.farao_community.farao.cse.runner.api.resource.ProcessType;
+import com.powsybl.glsk.commons.ZonalData;
+import com.powsybl.iidm.modification.scalable.Scalable;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VariantManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Map;
 
@@ -24,25 +38,28 @@ class InitialShiftServiceTest {
     @Autowired
     InitialShiftService initialShiftService;
 
+    @MockitoBean
+    ZonalScalableProvider zonalScalableProvider;
+
     @Test
     void getInitialShiftValues() {
         Ntc ntc = Mockito.mock(Ntc.class);
         CseData cseData = Mockito.mock(CseData.class);
         Map<String, Double> flowPerCountryOnNotModelizedLines = Map.of(
-            "AT", 10.,
-            "CH", 20.,
-            "FR", 30.,
-            "SI", 40.);
+                "AT", 10.,
+                "CH", 20.,
+                "FR", 30.,
+                "SI", 40.);
         Map<String, Double> referenceExchanges = Map.of(
-            CseCountry.AT.getEiCode(), 1.,
-            CseCountry.CH.getEiCode(), 2.,
-            CseCountry.FR.getEiCode(), 3.,
-            CseCountry.SI.getEiCode(), 4.);
+                CseCountry.AT.getEiCode(), 1.,
+                CseCountry.CH.getEiCode(), 2.,
+                CseCountry.FR.getEiCode(), 3.,
+                CseCountry.SI.getEiCode(), 4.);
         Map<String, Double> ntcsByEic = Map.of(
-            CseCountry.AT.getEiCode(), 100.,
-            CseCountry.CH.getEiCode(), 200.,
-            CseCountry.FR.getEiCode(), 300.,
-            CseCountry.SI.getEiCode(), 400.);
+                CseCountry.AT.getEiCode(), 100.,
+                CseCountry.CH.getEiCode(), 200.,
+                CseCountry.FR.getEiCode(), 300.,
+                CseCountry.SI.getEiCode(), 400.);
 
         Mockito.when(cseData.getNtc()).thenReturn(ntc);
         Mockito.when(ntc.getFlowPerCountryOnNotModelizedLines()).thenReturn(flowPerCountryOnNotModelizedLines);
@@ -57,4 +74,67 @@ class InitialShiftServiceTest {
             .containsEntry(CseCountry.IT.getEiCode(), -890.);
     }
 
+    @Test
+    void loadflowDivergenceBeforeShift() {
+        try (MockedStatic<BorderExchanges> mockedBorderExchanges = Mockito.mockStatic(BorderExchanges.class);
+             MockedConstruction<CseNetworkExporter> mockedCseNetworkExporter = Mockito.mockConstruction(CseNetworkExporter.class)) {
+
+            mockedBorderExchanges.when(() -> BorderExchanges.computeCseCountriesBalances(Mockito.any(Network.class)))
+                    .thenThrow(LoadflowComputationException.class);
+
+            final Network network = Mockito.mock(Network.class);
+
+            Assertions.assertThatExceptionOfType(LoadflowComputationException.class)
+                    .isThrownBy(() -> initialShiftService.performInitialShiftFromVulcanusLevelToNtcLevel(network, null, null, null, null));
+            Assertions.assertThat(mockedCseNetworkExporter.constructed()).hasSize(1);
+            Mockito.verify(mockedCseNetworkExporter.constructed().getFirst(), Mockito.times(1)).export(network, "beforeInitialShift");
+        }
+    }
+
+    @Test
+    void loadflowDivergenceAfterShift() {
+        try (MockedStatic<BorderExchanges> mockedBorderExchanges = Mockito.mockStatic(BorderExchanges.class);
+             MockedStatic<NetworkShifterUtil> mockedNetworkShifterUtil = Mockito.mockStatic(NetworkShifterUtil.class);
+             MockedConstruction<CseNetworkExporter> mockedCseNetworkExporter = Mockito.mockConstruction(CseNetworkExporter.class)) {
+
+            // Given
+            final Map<String, Double> commonEiCodeMap = Map.of(
+                    CseCountry.FR.getEiCode(), 0.,
+                    CseCountry.CH.getEiCode(), 0.,
+                    CseCountry.AT.getEiCode(), 0.,
+                    CseCountry.SI.getEiCode(), 0.);
+            mockedBorderExchanges.when(() -> BorderExchanges.computeCseCountriesBalances(Mockito.any(Network.class)))
+                    .thenReturn(commonEiCodeMap)
+                    .thenThrow(LoadflowComputationException.class);
+            mockedNetworkShifterUtil.when(() -> NetworkShifterUtil.convertMapByCountryToMapByEic(Mockito.anyMap()))
+                    .thenReturn(commonEiCodeMap);
+
+            final Network network = Mockito.mock(Network.class);
+            final VariantManager variantManager = Mockito.mock(VariantManager.class);
+            Mockito.when(network.getVariantManager()).thenReturn(variantManager);
+            Mockito.when(variantManager.getWorkingVariantId()).thenReturn("test");
+
+            final CseRequest cseRequest = Mockito.mock(CseRequest.class);
+            Mockito.when(cseRequest.getProcessType()).thenReturn(ProcessType.D2CC);
+
+            final CseData cseData = Mockito.mock(CseData.class);
+            final Ntc ntc = Mockito.mock(Ntc.class);
+            Mockito.when(cseData.getNtc()).thenReturn(ntc);
+            Mockito.when(ntc.getFlowPerCountryOnNotModelizedLines()).thenReturn(commonEiCodeMap);
+
+            final ZonalData<Scalable> zonalData = Mockito.mock(ZonalData.class);
+            final Scalable scalable = Mockito.mock(Scalable.class);
+            Mockito.when(zonalScalableProvider.get(Mockito.any(), Mockito.any(), Mockito.any()))
+                    .thenReturn(zonalData);
+            Mockito.when(zonalData.getData(Mockito.any())).thenReturn(scalable);
+            Mockito.when(scalable.scale(Mockito.any(), Mockito.anyDouble(), Mockito.any()))
+                    .thenReturn(0.);
+
+            // When-Then
+            Assertions.assertThatExceptionOfType(LoadflowComputationException.class)
+                    .isThrownBy(() -> initialShiftService.performInitialShiftFromVulcanusLevelToNtcLevel(network, cseData, cseRequest, commonEiCodeMap, commonEiCodeMap));
+            Assertions.assertThat(mockedCseNetworkExporter.constructed()).hasSize(1);
+            Mockito.verify(mockedCseNetworkExporter.constructed().getFirst(), Mockito.times(1)).export(network, "afterInitialShift");
+        }
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically export and upload network snapshots when loadflow computation diverges, labeled by step (e.g., beforeInitialShift, afterInitialShift).

- Improvements
  - Unified export flow to build destination paths from step context; exported filenames use “-diverged.uct” suffix.

- Tests
  - Added tests covering divergence before/after initial shift, updated expectations for “-diverged.uct”, and stabilized zone/time behavior in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->