### PR TITLE
Exclude equivalent generators of pisa hvdc from active power control

### DIFF
--- a/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/PiSaServiceTest.java
+++ b/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/PiSaServiceTest.java
@@ -154,7 +154,7 @@ class PiSaServiceTest {
     }
 
     @Test
-    void generatorPandTargetPAreEqualAfterLoadflow() {
+    void generatorPAndTargetPAreEqualAfterLoadflow() {
 
         // Given
         final Network network = Network.read("20210901_2230_test_network_pisa_test_both_links_connected_setpoint_and_emulation_ok_for_run.uct",
@@ -162,8 +162,8 @@ class PiSaServiceTest {
         piSaService.alignGenerators(network);
         //when
         LoadFlowUtil.runLoadFlowWithMdc(network, network.getVariantManager().getWorkingVariantId(), LoadFlowParameters.load());
-        final Generator frFictiveGenerator = piSaService.getPiSaLink1Processor().getFrFictiveGenerator(network);
         //then
+        final Generator frFictiveGenerator = piSaService.getPiSaLink1Processor().getFrFictiveGenerator(network);
         Assertions.assertThat(Math.abs(frFictiveGenerator.getTerminal().getP()))
                 .isEqualTo(Math.abs(frFictiveGenerator.getTargetP()));
         final Generator itFictiveGenerator = piSaService.getPiSaLink1Processor().getItFictiveGenerator(network);

--- a/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/PiSaServiceTest.java
+++ b/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/PiSaServiceTest.java
@@ -154,7 +154,7 @@ class PiSaServiceTest {
     }
 
     @Test
-    void generatorPAndTargetPAreEqualAfterLoadflow() {
+    void generatorPowerEqualsTargetPowerAfterLoadflow() {
 
         // Given
         final Network network = Network.read("20210901_2230_test_network_pisa_test_both_links_connected_setpoint_and_emulation_ok_for_run.uct",

--- a/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/PiSaServiceTest.java
+++ b/cse-cc-import-runner-app/src/test/java/com/farao_community/farao/cse/import_runner/app/services/PiSaServiceTest.java
@@ -11,6 +11,7 @@ import com.farao_community.farao.cse.computation.LoadFlowUtil;
 import com.farao_community.farao.cse.runner.api.resource.ProcessType;
 import com.powsybl.iidm.network.Generator;
 import com.powsybl.loadflow.LoadFlowParameters;
+import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.openrao.data.crac.api.Crac;
 import com.powsybl.openrao.data.crac.api.parameters.CracCreationParameters;
 import com.powsybl.iidm.network.Network;
@@ -161,8 +162,9 @@ class PiSaServiceTest {
                                              getClass().getResourceAsStream("20210901_2230_test_network_pisa_test_both_links_connected_setpoint_and_emulation_ok_for_run.uct"));
         piSaService.alignGenerators(network);
         //when
-        LoadFlowUtil.runLoadFlowWithMdc(network, network.getVariantManager().getWorkingVariantId(), LoadFlowParameters.load());
+        LoadFlowResult result = LoadFlowUtil.runLoadFlowWithMdc(network, network.getVariantManager().getWorkingVariantId(), LoadFlowParameters.load());
         //then
+        Assertions.assertThat(result.isFailed()).isFalse();
         final Generator frFictiveGenerator = piSaService.getPiSaLink1Processor().getFrFictiveGenerator(network);
         Assertions.assertThat(Math.abs(frFictiveGenerator.getTerminal().getP()))
                 .isEqualTo(Math.abs(frFictiveGenerator.getTargetP()));

--- a/cse-lib/network-processing/pom.xml
+++ b/cse-lib/network-processing/pom.xml
@@ -31,6 +31,10 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-ucte-converter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-impl</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/cse-lib/network-processing/src/main/java/com/farao_community/farao/cse/network_processing/pisa_change/PiSaLinkProcessor.java
+++ b/cse-lib/network-processing/src/main/java/com/farao_community/farao/cse/network_processing/pisa_change/PiSaLinkProcessor.java
@@ -10,6 +10,8 @@ package com.farao_community.farao.cse.network_processing.pisa_change;
 import com.powsybl.iidm.network.Generator;
 import com.powsybl.iidm.network.Line;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.extensions.ActivePowerControl;
+import com.powsybl.iidm.network.impl.extensions.ActivePowerControlImpl;
 import com.powsybl.openrao.data.crac.api.Crac;
 import com.powsybl.openrao.data.crac.api.Identifiable;
 import com.powsybl.openrao.data.crac.api.rangeaction.InjectionRangeAction;
@@ -162,11 +164,14 @@ public class PiSaLinkProcessor {
     /**
      * Put both generators at same absolute value of target P but opposite sign. It is aligned on the highest
      * absolute value of target P.
+     * Also initiate generator configuration to set activePowerControl participation to false
      *
      * @param generator1: First generator to align.
      * @param generator2: Second generator to align.
      */
     static void alignGenerators(Generator generator1, Generator generator2) {
+        generator1.addExtension(ActivePowerControl.class, new ActivePowerControlImpl<>(generator1, false, Double.NaN, Double.NaN));
+        generator2.addExtension(ActivePowerControl.class, new ActivePowerControlImpl<>(generator2, false, Double.NaN, Double.NaN));
         if (Math.abs(generator1.getTargetP()) > Math.abs(generator2.getTargetP())) {
             generator2.setTargetP(-generator1.getTargetP());
         } else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a validation test that verifies generator terminal power matches target values after running a load-flow.

* **Enhancements**
  * Generators now include active power control setup to improve alignment during load-flow operations.

* **Chores**
  * Added a runtime dependency to support the new active power control behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->